### PR TITLE
Fix typo in Example 3.2 of Unique Resource Identifier

### DIFF
--- a/metadata/metadata-iso19139/metadata-iso19139.adoc
+++ b/metadata/metadata-iso19139/metadata-iso19139.adoc
@@ -2182,7 +2182,7 @@ The persistence and process of preventing breaking the identifier resolvability 
       <gmd:identifier>
         <gmd:md_identifier>
           <gmd:code>
-            <gmx:anchor <="" gmx:anchor="" xlink:href="https://registry.gdi-de.org/id/de.nw/inspire-cp-alkis">
+            <gmx:anchor xlink:href="https://registry.gdi-de.org/id/de.nw/inspire-cp-alkis">
             </gmx:anchor>
           </gmd:code>
         </gmd:md_identifier>


### PR DESCRIPTION
In the Example 3.2 XML snippet there's an error in the syntax. This PR aims to only correct a potential XML validation, in case it is used as-is in a metadata doc. It's not intended to validate the context of its proper INSPIRE syntax and content.